### PR TITLE
Fixes lint warning in cibuild

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -1,7 +1,7 @@
 # Public: Set the global default phantomjs version
 #
 # Usage: phantomjs::global { '1.9.0': }
-class phantomjs::global($version) {
+class phantomjs::global($version = undef) {
   require phantomjs
   $klass = join(['phantomjs', join(split($version, '[.]'), '_')], '::')
   require $klass


### PR DESCRIPTION
Fixes the following warning preventing green Travis badge:

```
manifests/global.pp - WARNING: parameterised class parameter without a default value on line 4
```
