### PR TITLE
convert global.pp class to a defined type

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -1,7 +1,7 @@
 # Public: Set the global default phantomjs version
 #
 # Usage: phantomjs::global { '1.9.0': }
-class phantomjs::global($version = undef) {
+define phantomjs::global($version = $title) {
   require phantomjs
   $klass = join(['phantomjs', join(split($version, '[.]'), '_')], '::')
   require $klass

--- a/spec/defines/phantomjs__global_spec.rb
+++ b/spec/defines/phantomjs__global_spec.rb
@@ -2,11 +2,7 @@ require "spec_helper"
 
 describe "phantomjs::global" do
   let(:facts) { default_test_facts }
-  let(:params) do
-    {
-      :version => "1.9.0"
-    }
-  end
+  let(:title) { "1.9.0" }
 
   it do
     should include_class("phantomjs")


### PR DESCRIPTION
This fixes the phantomjs::global resource issue that people are running into (https://github.com/boxen/puppet-phantomjs/issues/8) by converting the resource to a defined type in line with how the phantomjs::version resource is structured.

It also sets the $version parameter to the $title so that the usage example given - phantomjs::global { '1.9.0': } - succeeds. 

The spec passes with a little modification.
