### PR TITLE
Update phantomjs to 1.9.7

### DIFF
--- a/manifests/1_9_7.pp
+++ b/manifests/1_9_7.pp
@@ -1,0 +1,5 @@
+# Public: Install PhantomJS 1.9.7
+
+class phantomjs::1_9_7 {
+  phantomjs::version { '1.9.7': }
+}


### PR DESCRIPTION
This should get rid of this [1] anoing CoreText warning.

[1] https://github.com/ariya/phantomjs/issues/11418
