### PR TITLE
Allow overriding the phantomenv repository

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 # Public: Install PhantomJS
 
 class phantomjs(
-  $phantomenv_root    = $phantomjs::params::phantomenv_root,
-  $phantomenv_user    = $phantomjs::params::phantomenv_user,
-  $phantomenv_version = $phantomjs::params::phantomenv_version,
+  $phantomenv_root       = $phantomjs::params::phantomenv_root,
+  $phantomenv_user       = $phantomjs::params::phantomenv_user,
+  $phantomenv_version    = $phantomjs::params::phantomenv_version,
+  $phantomenv_repository = $phantomjs::params::phantomenv_repository,
 ) inherits phantomjs::params {
   if $::osfamily == 'Darwin'{
     include homebrew
@@ -25,7 +26,7 @@ class phantomjs(
   repository { $phantomenv_root:
     ensure => $phantomenv_version,
     force  => true,
-    source => 'wfarr/phantomenv',
+    source => $phantomenv_repository,
     user   => $phantomenv_user,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,5 +15,6 @@ class phantomjs::params {
     }
   }
 
-  $phantomenv_version = 'v0.0.8'
+  $phantomenv_repository = 'wfarr/phantomenv'
+  $phantomenv_version    = 'v0.0.8'
 }


### PR DESCRIPTION
This allows me to use my local hiera configuration to set a phantomenv repository that has been updated recently e.g. I am using this repo: https://github.com/antonio/phantomenv/tree/download_links

The more correct solution to this would be to update phantomenv but unfortunately it doesn't seem like it will happen soon - there's a 2 month old pull request with no feedback here: https://github.com/wfarr/phantomenv/pull/3
