### PR TITLE
Fixes Outdated Binary Download URLs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,6 @@ class phantomjs::params {
     }
   }
 
-  $phantomenv_repository = 'wfarr/phantomenv'
-  $phantomenv_version    = 'v0.0.8'
+  $phantomenv_repository = 'boxen/phantomenv'
+  $phantomenv_version    = 'v0.0.9'
 }

--- a/spec/classes/phantomjs_spec.rb
+++ b/spec/classes/phantomjs_spec.rb
@@ -11,8 +11,8 @@ describe "phantomjs" do
     should contain_boxen__env_script("phantomjs")
 
     should contain_repository("/test/boxen/phantomenv").with({
-      :ensure => "v0.0.8",
-      :source => "wfarr/phantomenv",
+      :ensure => "v0.0.9",
+      :source => "boxen/phantomenv",
       :user   => "testuser"
     })
   end

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,4 +1,4 @@
-mod "boxen",      "3.1.0", :github_tarball => "boxen/puppet-boxen"
+mod "boxen",      "3.2.0", :github_tarball => "boxen/puppet-boxen"
 mod "homebrew",   "1.4.1", :github_tarball => "boxen/puppet-homebrew"
 mod "repository", "2.2.0", :github_tarball => "boxen/puppet-repository"
 mod "stdlib",     "4.1.0", :github_tarball => "puppetlabs/puppetlabs-stdlib"


### PR DESCRIPTION
Phantomenv has been moved into the [boxen][1] organization, and an updated release has been issued to address broken binary download URLs. Resolves boxen/puppet-phantomjs#16.

Also, puppet dependencies have been updated in the spec suite to keep 'em green.

[1]: https://github.com/boxen