### PR TITLE
Allow specifying any PhantomJS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
----
+sudo: false
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "cardboard"
 gem 'rspec', '< 2.99'
+gem "highline", "~> 1.6.19"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     hiera (1.3.4)
       json_pure
-    highline (1.7.2)
+    highline (1.6.21)
     json (1.8.2)
     json_pure (1.8.2)
     librarian (0.1.2)
@@ -73,4 +73,5 @@ PLATFORMS
 
 DEPENDENCIES
   cardboard
+  highline (~> 1.6.19)
   rspec (< 2.99)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ include phantomjs
 # Install PhantomJS version 1.9.0
 phantomjs::version { '1.9.0': }
 
-# The two commands above in one line
-include phantomjs::1_9_0
-
 # Sets local version of PhantomJS, writes .phantomenv file to directory specified (version should be installed already)
 phantomjs::local { '/path/to/whatever':
   version => '1.9.0'

--- a/manifests/1_7_0.pp
+++ b/manifests/1_7_0.pp
@@ -1,5 +1,0 @@
-# Public: Install PhantomJS 1.7.0
-
-class phantomjs::1_7_0 {
-  phantomjs::version { '1.7.0': }
-}

--- a/manifests/1_8_0.pp
+++ b/manifests/1_8_0.pp
@@ -1,5 +1,0 @@
-# Public: Install PhantomJS 1.8.0
-
-class phantomjs::1_8_0 {
-  phantomjs::version { '1.8.0': }
-}

--- a/manifests/1_8_1.pp
+++ b/manifests/1_8_1.pp
@@ -1,5 +1,0 @@
-# Public: Install PhantomJS 1.8.1
-
-class phantomjs::1_8_1 {
-  phantomjs::version { '1.8.1': }
-}

--- a/manifests/1_8_2.pp
+++ b/manifests/1_8_2.pp
@@ -1,5 +1,0 @@
-# Public: Install PhantomJS 1.8.2
-
-class phantomjs::1_8_2 {
-  phantomjs::version { '1.8.2': }
-}

--- a/manifests/1_9_0.pp
+++ b/manifests/1_9_0.pp
@@ -1,5 +1,0 @@
-# Public: Install PhantomJS 1.9.0
-
-class phantomjs::1_9_0 {
-  phantomjs::version { '1.9.0': }
-}

--- a/manifests/1_9_7.pp
+++ b/manifests/1_9_7.pp
@@ -1,5 +1,0 @@
-# Public: Install PhantomJS 1.9.7
-
-class phantomjs::1_9_7 {
-  phantomjs::version { '1.9.7': }
-}

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -1,13 +1,12 @@
 # Public: Set the global default phantomjs version
 #
-# Usage: phantomjs::global { '1.9.0': }
-define phantomjs::global($version = $title) {
+# Usage: phantomjs::global { '1.9.8': }
+define phantomjs::global {
   require phantomjs
-  $klass = join(['phantomjs', join(split($version, '[.]'), '_')], '::')
-  require $klass
+  ensure_resource('phantomjs::version', $title)
 
   file { "${phantomjs::phantomenv_root}/version":
-    content => "${version}\n",
+    content => "${title}\n",
     replace => true,
   }
 }

--- a/manifests/local.pp
+++ b/manifests/local.pp
@@ -12,8 +12,7 @@ define phantomjs::local($version = undef, $ensure = present) {
   validate_absolute_path($name)
 
   if $ensure == present {
-    $klass = join(['phantomjs', join(split($version, '[.]'), '_')], '::')
-    require $klass
+    ensure_resource('phantomjs::version', $version)
   }
 
   file { "${name}/.phantom-version":

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -1,6 +1,6 @@
 # Public: Install a PhantomJS version with phantomenv
 #
-# Usage: phantomjs::version { '1.2.3': }
+# Usage: phantomjs::version { '1.9.8': }
 
 define phantomjs::version($ensure = present) {
   require phantomjs

--- a/spec/classes/phantomjs__1_7_0_spec.rb
+++ b/spec/classes/phantomjs__1_7_0_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-describe "phantomjs::1_7_0" do
-  let(:facts) { default_test_facts }
-
-  it do
-    should contain_phantomjs__version("1.7.0")
-  end
-end

--- a/spec/classes/phantomjs__1_8_0_spec.rb
+++ b/spec/classes/phantomjs__1_8_0_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-describe "phantomjs::1_8_0" do
-  let(:facts) { default_test_facts }
-
-  it do
-    should contain_phantomjs__version("1.8.0")
-  end
-end

--- a/spec/classes/phantomjs__1_8_1_spec.rb
+++ b/spec/classes/phantomjs__1_8_1_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-describe "phantomjs::1_8_1" do
-  let(:facts) { default_test_facts }
-
-  it do
-    should contain_phantomjs__version("1.8.1")
-  end
-end

--- a/spec/classes/phantomjs__1_8_2_spec.rb
+++ b/spec/classes/phantomjs__1_8_2_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-describe "phantomjs::1_8_2" do
-  let(:facts) { default_test_facts }
-
-  it do
-    should contain_phantomjs__version("1.8.2")
-  end
-end

--- a/spec/classes/phantomjs__1_9_0_spec.rb
+++ b/spec/classes/phantomjs__1_9_0_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-describe "phantomjs::1_9_0" do
-  let(:facts) { default_test_facts }
-
-  it do
-    should contain_phantomjs__version("1.9.0")
-  end
-end

--- a/spec/defines/phantomjs__global_spec.rb
+++ b/spec/defines/phantomjs__global_spec.rb
@@ -6,7 +6,6 @@ describe "phantomjs::global" do
 
   it do
     should include_class("phantomjs")
-    should include_class("phantomjs::1_9_0")
 
     should contain_file("/test/boxen/phantomenv/version").with({
       :content => "1.9.0\n",

--- a/spec/defines/phantomjs__local_spec.rb
+++ b/spec/defines/phantomjs__local_spec.rb
@@ -13,8 +13,6 @@ describe "phantomjs::local" do
   let(:params) { default_params }
 
   it do
-    should include_class("phantomjs::1_9_0")
-
     should contain_file("/path/to/wherever/.phantom-version").with({
       :ensure  => "present",
       :content => "1.9.0\n",
@@ -26,8 +24,6 @@ describe "phantomjs::local" do
     let(:params) { default_params.merge(:ensure => "absent") }
 
     it do
-      should_not include_class("phantomjs::1_9_0")
-
       should contain_file("/path/to/wherever/.phantom-version").with({
         :ensure => "absent"
       })


### PR DESCRIPTION
Allows specifying PhantomJS versions 1.9.8, 2.0.0 and up.

Ditches the old approach of having hardcoded classes for each version. That didn't make sense to me.

<img width=400 src="http://i.imgur.com/xVyoSl.jpg">
